### PR TITLE
chore: rename package to use @powersync

### DIFF
--- a/.changeset/odd-timers-hunt.md
+++ b/.changeset/odd-timers-hunt.md
@@ -1,0 +1,5 @@
+---
+"@powersync/wa-sqlite": patch
+---
+
+Rename package to @powersync/wa-sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# @journeyapps/wa-sqlite
+# @powersync/wa-sqlite
+
+## For the following previous versions refer to `@journeyapps/wa-sqlite`
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![wa-sqlite CI](https://github.com/rhashimoto/wa-sqlite/actions/workflows/ci.yml/badge.svg?branch=breaking-changes)](https://github.com/rhashimoto/wa-sqlite/actions/workflows/ci.yml?branch=breaking-changes)
+[![wa-sqlite CI](https://github.com/powersync-ja/wa-sqlite/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/powersync-ja/wa-sqlite/actions/workflows/ci.yml?branch=master)
 
 # Beta
 This package is currently in a beta release.
@@ -7,13 +7,13 @@ This package is currently in a beta release.
 # wa-sqlite
 This is a WebAssembly build of SQLite with experimental support for writing SQLite virtual filesystems and virtual table modules completely in Javascript. This allows alternative browser storage options such as IndexedDB and File System Access. Applications can opt to use either a synchronous or asynchronous (using Asyncify) SQLite library build (an asynchronous build is required for asynchronous extensions).
 
-[IndexedDB](https://github.com/rhashimoto/wa-sqlite/blob/master/src/examples/IDBMinimalVFS.js) and [Origin Private File System](https://github.com/rhashimoto/wa-sqlite/blob/master/src/examples/OriginPrivateFileSystemVFS.js) virtual file systems and a [virtual table module that accesses Javascript arrays](https://github.com/rhashimoto/wa-sqlite/blob/master/src/examples/ArrayModule.js) are among the examples provided as proof of concept.
+[IndexedDB](https://github.com/powersync-ja/wa-sqlite/blob/master/src/examples/IDBMinimalVFS.js) and [Origin Private File System](https://github.com/powersync-ja/wa-sqlite/blob/master/src/examples/OriginPrivateFileSystemVFS.js) virtual file systems and a [virtual table module that accesses Javascript arrays](https://github.com/powersync-ja/wa-sqlite/blob/master/src/examples/ArrayModule.js) are among the examples provided as proof of concept.
 
 [Try the demo](https://rhashimoto.github.io/wa-sqlite/demo/) or run [benchmarks](https://rhashimoto.github.io/wa-sqlite/demo/benchmarks.html) with a modern desktop web browser. More information is available in the [FAQ](https://github.com/rhashimoto/wa-sqlite/issues?q=is%3Aissue+label%3Afaq+), [discussion forums](https://github.com/rhashimoto/wa-sqlite/discussions), and [API reference](https://rhashimoto.github.io/wa-sqlite/docs/).
 
 ## Build
 The primary motivation for this project is to enable additions to SQLite with only Javascript. Most developers should be able to use the pre-built artifacts in
-[./dist](https://github.com/rhashimoto/wa-sqlite/tree/master/dist).
+[./dist](https://github.com/powersync-ja/wa-sqlite/tree/master/dist).
 Note that earlier versions of the project only provided pre-built artifacts in the
 "buildless" branch; that branch will no longer be maintained.
 
@@ -33,9 +33,9 @@ Here are the build steps:
 
 The default build produces ES6 modules + WASM, [synchronous and asynchronous](https://github.com/rhashimoto/wa-sqlite/issues/7) (using Asyncify) in `dist/`.
 
-## JouneyApps instructions
+## PowerSync instructions
 
-Note as per above that this is known to compile under Debian. 
+Note as per above that this is known to compile under Debian.
 
 MacOS initially complained about OpenSSL config. Compiling on MacOS may be possible with additional config, but this is currently unknown.
 
@@ -44,7 +44,6 @@ Development has been done using VSCode's [development container](https://code.vi
 ```bash
 git clone [this repo]
 ```
-
 
 ```bash
 git submodule init
@@ -56,14 +55,11 @@ git submodule update --init --recursive
 
 ```bash
 yarn install
-
 ```
 
-
-```bash 
+```bash
 make -B
 ```
-
 
 ## API
 Javascript wrappers for core SQLITE C API functions (and some others) are provided. Some convenience functions are also provided to reduce boilerplate. Here's sample code to load the library and call the API:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@journeyapps/wa-sqlite",
+  "name": "@powersync/wa-sqlite",
   "version": "0.2.0",
   "publishConfig": {
     "access": "public"

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -670,7 +670,7 @@ declare interface SQLiteAPI {
 
   /**
    * Registers table row on change callback
-   * 
+   *
    */
   register_table_onchange_hook(db: number, callback: (opType: number, tableName: string, rowId: number) => void): void;
 
@@ -1023,7 +1023,7 @@ declare interface SQLiteAPI {
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/src/sqlite-constants.js' {
+declare module '@powersync/wa-sqlite/src/sqlite-constants.js' {
   export const SQLITE_OK: 0;
   export const SQLITE_ERROR: 1;
   export const SQLITE_INTERNAL: 2;
@@ -1256,8 +1256,8 @@ declare module '@journeyapps/wa-sqlite/src/sqlite-constants.js' {
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite' {
-  export * from '@journeyapps/wa-sqlite/src/sqlite-constants.js';
+declare module '@powersync/wa-sqlite' {
+  export * from '@powersync/wa-sqlite/src/sqlite-constants.js';
 
   /**
    * Builds a Javascript API from the Emscripten module. This API is still
@@ -1275,20 +1275,20 @@ declare module '@journeyapps/wa-sqlite' {
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/dist/wa-sqlite.mjs' {
+declare module '@powersync/wa-sqlite/dist/wa-sqlite.mjs' {
   function ModuleFactory(config?: object): Promise<any>;
   export = ModuleFactory;
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/dist/wa-sqlite-async.mjs' {
+declare module '@powersync/wa-sqlite/dist/wa-sqlite-async.mjs' {
   function ModuleFactory(config?: object): Promise<any>;
   export = ModuleFactory;
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/src/VFS.js' {
-  export * from '@journeyapps/wa-sqlite/src/sqlite-constants.js';
+declare module '@powersync/wa-sqlite/src/VFS.js' {
+  export * from '@powersync/wa-sqlite/src/sqlite-constants.js';
 
   export class Base {
     mxPathName: number;
@@ -1533,7 +1533,7 @@ declare module 'wa-sqlite/src/examples/ArrayModule.js' {
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/src/examples/ArrayAsyncModule.js' {
+declare module '@powersync/wa-sqlite/src/examples/ArrayAsyncModule.js' {
   import { ArrayModule } from 'wa-sqlite/src/examples/ArrayModule.js';
   export class ArrayAsyncModule extends ArrayModule {
     /**
@@ -1545,8 +1545,8 @@ declare module '@journeyapps/wa-sqlite/src/examples/ArrayAsyncModule.js' {
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/src/examples/AccessHandlePoolVFS.js' {
-  import * as VFS from '@journeyapps/wa-sqlite/src/VFS.js';
+declare module '@powersync/wa-sqlite/src/examples/AccessHandlePoolVFS.js' {
+  import * as VFS from '@powersync/wa-sqlite/src/VFS.js';
   export class AccessHandlePoolVFS extends VFS.Base {
     /**
      * @param {string} directoryPath Flat directory where all OPFS files are stored
@@ -1556,8 +1556,8 @@ declare module '@journeyapps/wa-sqlite/src/examples/AccessHandlePoolVFS.js' {
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js' {
-  import * as VFS from '@journeyapps/wa-sqlite/src/VFS.js';
+declare module '@powersync/wa-sqlite/src/examples/IDBBatchAtomicVFS.js' {
+  import * as VFS from '@powersync/wa-sqlite/src/VFS.js';
   export class IDBBatchAtomicVFS extends VFS.Base {
     /**
      * @param {string} idbDatabaseName IndexDB DB name
@@ -1574,14 +1574,14 @@ declare module '@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js' {
 
 /** @ignore */
 declare module '@journeyapp/wa-sqlite/src/examples/IDBVersionedVFS.js' {
-  import {IDBBatchAtomicVFS} from '@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js';
+  import {IDBBatchAtomicVFS} from '@powersync/wa-sqlite/src/examples/IDBBatchAtomicVFS.js';
   export class IDBVersionedVFS extends IDBBatchAtomicVFS {}
 }
 
 
 /** @ignore */
 declare module '@journeyapp/wa-sqlite/src/examples/OriginPrivatefileSystemVFS.js' {
-  import * as VFS from '@journeyapps/wa-sqlite/src/VFS.js';
+  import * as VFS from '@powersync/wa-sqlite/src/VFS.js';
   export class OriginPrivateFileSystemVFS extends VFS.Base {
     close(): Promise<void>;
   }
@@ -1589,7 +1589,7 @@ declare module '@journeyapp/wa-sqlite/src/examples/OriginPrivatefileSystemVFS.js
 
 /** @ignore */
 declare module 'wa-sqlite/src/examples/IDBMinimalVFS.js' {
-  import * as VFS from '@journeyapps/wa-sqlite/src/VFS.js';
+  import * as VFS from '@powersync/wa-sqlite/src/VFS.js';
   export class IDBMinimalVFS extends VFS.Base {
     /**
      * @param {string} idbDatabaseName IndexDB DB name
@@ -1603,8 +1603,8 @@ declare module 'wa-sqlite/src/examples/IDBMinimalVFS.js' {
 }
 
 /** @ignore */
-declare module '@journeyapps/wa-sqlite/src/examples/IndexedDbVFS.js' {
-  import * as VFS from '@journeyapps/wa-sqlite/src/VFS.js';
+declare module '@powersync/wa-sqlite/src/examples/IndexedDbVFS.js' {
+  import * as VFS from '@powersync/wa-sqlite/src/VFS.js';
   export class IndexedDbVFS extends VFS.Base {
     /**
      * @param {string} idbName Name of IndexedDB database.
@@ -1657,7 +1657,7 @@ declare module '@journeyapps/wa-sqlite/src/examples/IndexedDbVFS.js' {
 
 /** @ignore */
 declare module 'wa-sqlite/src/examples/MemoryVFS.js' {
-  import * as VFS from '@journeyapps/wa-sqlite/src/VFS.js';
+  import * as VFS from '@powersync/wa-sqlite/src/VFS.js';
   export class MemoryVFS extends VFS.Base {
     name: string;
     mapNameToFile: Map<any, any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,32 +309,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@journeyapps/wa-sqlite@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@journeyapps/wa-sqlite@workspace:."
-  dependencies:
-    "@changesets/cli": ^2.26.2
-    "@web/dev-server": ^0.1.13
-    comlink: ^4.4.1
-    jasmine-core: ^4.5.0
-    karma: ^6.4.1
-    karma-chrome-launcher: ^3.1.1
-    karma-jasmine: ^5.1.0
-    monaco-editor: ^0.34.1
-    puppeteer: ^19.6.3
-    sinon: 15.0.1
-    typedoc: ^0.22.11
-    typescript: ^4.2.4
-  dependenciesMeta:
-    comlink@4.4.1:
-      unplugged: true
-    monaco-editor@0.34.1:
-      unplugged: true
-    sinon@15.0.1:
-      unplugged: true
-  languageName: unknown
-  linkType: soft
-
 "@manypkg/find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "@manypkg/find-root@npm:1.1.0"
@@ -416,6 +390,32 @@ __metadata:
   checksum: 6ad6a00fc4f2f2cfc6bff76fb1d88b8ee20bc0601e18ebb01b6d4be583733a860239a521a7fbca73b612e66705078809483549d2b18f370eb346c5155c8e4a0f
   languageName: node
   linkType: hard
+
+"@powersync/wa-sqlite@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@powersync/wa-sqlite@workspace:."
+  dependencies:
+    "@changesets/cli": ^2.26.2
+    "@web/dev-server": ^0.1.13
+    comlink: ^4.4.1
+    jasmine-core: ^4.5.0
+    karma: ^6.4.1
+    karma-chrome-launcher: ^3.1.1
+    karma-jasmine: ^5.1.0
+    monaco-editor: ^0.34.1
+    puppeteer: ^19.6.3
+    sinon: 15.0.1
+    typedoc: ^0.22.11
+    typescript: ^4.2.4
+  dependenciesMeta:
+    comlink@4.4.1:
+      unplugged: true
+    monaco-editor@0.34.1:
+      unplugged: true
+    sinon@15.0.1:
+      unplugged: true
+  languageName: unknown
+  linkType: soft
 
 "@puppeteer/browsers@npm:0.5.0":
   version: 0.5.0


### PR DESCRIPTION
## Description

This changes the name of the package to @powersync/wa-sqlite

Todos after this:

 - [ ] We need to update docs with references to old package on Gitbook and other README's
 - [ ] Update demos to use new package name