### PR TITLE
[Fix] Table Change Notifications Memory

### DIFF
--- a/.changeset/stale-cups-grow.md
+++ b/.changeset/stale-cups-grow.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/wa-sqlite': patch
+---
+
+Fix bug where table change update notifications would access invalid memory locations under certain conditions.

--- a/src/sqlite-api.js
+++ b/src/sqlite-api.js
@@ -27,7 +27,7 @@ const async = true;
 
 const onTableChangeCallbacks = {};
 globalThis.__onTablesChanged = function(db, opType, tableName, rowId) {
-  setTimeout(() => onTableChangeCallbacks[db]?.(opType, tableName, rowId), 0);
+  onTableChangeCallbacks[db]?.(opType, tableName, rowId);
 };
 
 /**
@@ -569,7 +569,12 @@ export function Factory(Module) {
       const stringBytes = new Uint8Array(Module.HEAPU8.buffer, tableNamePtr, length);
       const tableName = new TextDecoder().decode(stringBytes);
 
-      return callback(opType, tableName, rowId);
+      /**
+       * Call the callback inside a setTimeout to avoid blocking SQLite.
+       * We use a setTimeout only after fetching data from the heap to avoid
+       * accessing memory which has been freed. 
+       */
+      setTimeout(() => callback(opType, tableName, rowId), 0)
     };
   };
 


### PR DESCRIPTION
# Overview

This fixes an issue where table change notifications would sometimes report "garbage" changed table names. 
For example see this snapshot of a batched notification:

```JSON
{
    "tables": [
        "\n",
        "",
        "���������B\u0001",
        "ps_migration"
    ],
    "groupedUpdates": {},
    "rawUpdates": []
}
```
The table names are extracted from the heap via the pointer provided by SQLite. We convert the C pointer to a JavaScript string in the update notification handler. 
SQLite3 executes the update hook synchronously. We execute our update notification callbacks in a `setTimeout` to avoid blocking SQLite3. This causes issues when using the provided pointer since the data could have been freed after SQLite's synchronous execution. 

This changes the order of operations to first fetch the table name strings synchronously then fire the downstream callbacks asynchronously. 
