### PR TITLE
[Fix] OPFS Potential Deadlocks

### DIFF
--- a/.changeset/fluffy-plums-carry.md
+++ b/.changeset/fluffy-plums-carry.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/wa-sqlite': patch
+---
+
+Fix potential deadlocks and Failed to execute 'createSyncAccessHandle' on 'FileSystemFileHandle' errors.

--- a/src/examples/OPFSCoopSyncVFS.js
+++ b/src/examples/OPFSCoopSyncVFS.js
@@ -519,17 +519,31 @@ export class OPFSCoopSyncVFS extends FacadeVFS {
       this._module.retryOps.push((async () => {
         // Acquire the Web Lock.
         file.persistentFile.handleLockReleaser = await this.#acquireLock(file.persistentFile);
-
-        // Get access handles for the database and releated files in parallel.
-        this.log?.(`creating access handles for ${file.path}`)
-        await Promise.all(DB_RELATED_FILE_SUFFIXES.map(async suffix => {
-          const persistentFile = this.persistentFiles.get(file.path + suffix);
-          if (persistentFile) {
-            persistentFile.accessHandle =
-              await persistentFile.fileHandle.createSyncAccessHandle();
-          }
-        }));
-        file.persistentFile.isRequestInProgress = false;
+        try {
+          // Get access handles for the database and releated files in parallel.
+          this.log?.(`creating access handles for ${file.path}`)
+          await Promise.all(DB_RELATED_FILE_SUFFIXES.map(async suffix => {
+            const persistentFile = this.persistentFiles.get(file.path + suffix);
+            if (persistentFile) {
+              persistentFile.accessHandle =
+                await persistentFile.fileHandle.createSyncAccessHandle();
+            }
+          }));
+        } catch (e) {
+          this.log?.(`failed to create access handles for ${file.path}`, e);
+          // Close any of the potentially opened access handles
+          DB_RELATED_FILE_SUFFIXES.forEach(async suffix => {
+            const persistentFile = this.persistentFiles.get(file.path + suffix);
+            if (persistentFile) {
+              persistentFile.accessHandle?.close();
+            }
+          });
+          // Release the lock, if we failed here, we'd need to obtain the lock later in order to retry
+          file.persistentFile.handleLockReleaser();
+          throw e;
+        } finally {
+          file.persistentFile.isRequestInProgress = false;
+        }
       })());
       return this._module.retryOps.at(-1);
     }

--- a/src/examples/OPFSCoopSyncVFS.js
+++ b/src/examples/OPFSCoopSyncVFS.js
@@ -532,15 +532,7 @@ export class OPFSCoopSyncVFS extends FacadeVFS {
         } catch (e) {
           this.log?.(`failed to create access handles for ${file.path}`, e);
           // Close any of the potentially opened access handles
-          DB_RELATED_FILE_SUFFIXES.forEach(async suffix => {
-            const persistentFile = this.persistentFiles.get(file.path + suffix);
-            if (persistentFile) {
-              persistentFile.accessHandle?.close();
-            }
-          });
-          // Release the lock, if we failed here, we'd need to obtain the lock later in order to retry
-          file.persistentFile.handleLockReleaser();
-          file.persistentFile.handleLockReleaser = null;
+          this.#releaseAccessHandle(file);
           throw e;
         } finally {
           file.persistentFile.isRequestInProgress = false;

--- a/src/examples/OPFSCoopSyncVFS.js
+++ b/src/examples/OPFSCoopSyncVFS.js
@@ -540,6 +540,7 @@ export class OPFSCoopSyncVFS extends FacadeVFS {
           });
           // Release the lock, if we failed here, we'd need to obtain the lock later in order to retry
           file.persistentFile.handleLockReleaser();
+          file.persistentFile.handleLockReleaser = null;
           throw e;
         } finally {
           file.persistentFile.isRequestInProgress = false;


### PR DESCRIPTION
# Overview

Related to:
- https://github.com/powersync-ja/powersync-js/issues/664
- https://github.com/powersync-ja/powersync-js/issues/785

The following issue is quite difficult to reproduce. I cannot reproduce it in this WA-SQLite demo. It can be reproduced in our PowerSync JS SDK.

When opening multiple tabs (approximately 5 or more) and rapidly cycling through the tabs and refreshing. Two possible issues can occur.

## A stuck navigator lock

When the SQLite database is opened, the `#requestAccessHandle` is called. This method requests a navigator lock which resolves to a releaser function. It then attempts to asynchronously create a synchronous access handle for the 3 sqlite persistent files. If, for any reason, the creation of the synchronous access handles failed, the lock does not seem to be released. The `open` call is retried, but is stuck on the request to obtain the lock (possibly since it's already obtained).

An example of when the open is stuck waiting for a lock
<img width="486" height="177" alt="image" src="https://github.com/user-attachments/assets/0da083cc-e343-4ca9-8c8f-4878fd118a78" />

I'm not exactly sure what could cause these calls to fail. Perhaps there is some browser behaviour which could cause these calls to fail.

If we `try...catch` this process and release the lock on error, then we no longer experience these deadlocks in our testing. 

## NoModificationAllowed Errors

In the above refreshing test, we often also see the follow error (which is easier to reproduce in Firefox)

```
Failed to execute 'createSyncAccessHandle' on 'FileSystemFileHandle': Access Handles cannot be created if there is another open Access Handle or Writable stream associated with the same file.
```

Again, not entirely sure why this is happening. The main theory at this point is that, for some reason, creating 1 of the 3 persistent access handles fail - but 1 or more of them might have succeeded. One the next retry we might be attempting to open an access handle which is already open.
 