### PR TITLE
Update to node 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [26]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js 20
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 26
           cache: yarn
       - name: Update npm
         run: |


### PR DESCRIPTION
Recent npm versions are no longer compatible with Node 20, so let's try upgrading to the latest stable Node version. This should fix the release process, where we install the latest npm version by default.