### PR TITLE
Fix automated release

### DIFF
--- a/.changeset/good-ads-hope.md
+++ b/.changeset/good-ads-hope.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/wa-sqlite": patch
+---
+
+Internal: Fix automated releases.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,11 @@ jobs:
         uses: actions/checkout@v5
       - name: Enable Corepack
         run: corepack enable
-      - name: Setup Node.js 20
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 26
           cache: yarn
-      - name: Update npm
-        run: |
-          npm install -g npm@latest
-          npm --version
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
Apologies for the PR spam. Installing the latest version of `npm` is broken because half of npm itself is a CommonJS build while some of its dependencies have started being ESM only ([failed release run](https://github.com/powersync-ja/wa-sqlite/actions/runs/29008923843/job/86087349836)).

I'm sure they'll fix that eventually, for now we'll just use the npm version included in Node. Because we've upgraded to Node 26, we no longer need to install npm manually, the default version is recent enough to support OIDC publishing.

I have tested this with a dev release, it seems like this finally gets things working.